### PR TITLE
Bug/#34 filter by date missing

### DIFF
--- a/src/core/data/services/directory/directory.service.ts
+++ b/src/core/data/services/directory/directory.service.ts
@@ -5,7 +5,7 @@ import Dexie from 'dexie';
 import { DexieService } from '../dexie/dexie.service';
 import { Item, ItemService } from '../item/item.service';
 import { DocumentType } from '../../enum/file-type.enum';
-import { FileService } from '../file/file.service'
+import { FileService } from '../file/file.service';
 
 export interface Directory {
   id?: number;

--- a/src/pages/portfolio/portfolio.html
+++ b/src/pages/portfolio/portfolio.html
@@ -39,7 +39,7 @@
         </ion-item>
         <ion-item>
             <ion-label stacked>Date from</ion-label>
-            <ion-datetime displayFormat="YYYY-MM-DD" [(ngModel)]="dateFromTerm"></ion-datetime>
+            <ion-datetime displayFormat="YYYY-MM-DD" [max]="dateMaxDate" [(ngModel)]="dateFromTerm"></ion-datetime>
         </ion-item>
         <ion-item>
           <ion-label stacked>Date to</ion-label>

--- a/src/pages/portfolio/portfolio.ts
+++ b/src/pages/portfolio/portfolio.ts
@@ -112,6 +112,11 @@ export class PortfolioPage {
     return (item.value as File).format === type;
   }
 
+  filterDate(item: Item, fromTo: any) {
+    // is between and includes same day
+    return (moment(item.chosen_date).isBetween(fromTo[0], fromTo[1], null, '[]'));
+  }
+
   async viewDoc(event: any, item: Item) {
     const file = <File>item.value;
     if (file.format === FileFormatType.PDF) {
@@ -127,8 +132,4 @@ export class PortfolioPage {
     }
   }
   
-  filterDate(item: Item, fromTo: any) {
-    // is between and includes same day
-    return (moment(item.chosen_date).isBetween(fromTo[0], fromTo[1], null, '[]'));
-  }
 }

--- a/src/pipes/filterfilespace.ts
+++ b/src/pipes/filterfilespace.ts
@@ -6,6 +6,11 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class FilterFileName implements PipeTransform {
 
   transform(fileName: string): string {
+    // On empty database there are no files
+    // TODO: revisit this
+    if (!fileName) {
+      return 'Name not defined';
+    }
     return fileName.replace('%20', ' ');
   }
 


### PR DESCRIPTION
## Observation
There was no way to filter by date.

## Reproduction Steps
Filter by date is missing

## Resolution Description
Using the builtin ion-datetime element I added a from date and to date to allow the user to select 
YYYY-MM-DD to filter documents.

I re-enabled the date fields so that one could see the filter working.

## Resolution Validation
Choose a "From date" and "To date" and documents will be filtered if the file date is on or between the dates. 
