### PR TITLE
#106 wip add android fingerprint auth

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -95,6 +95,7 @@
     <plugin name="cordova-plugin-email-composer" spec="^0.8.13" />
     <plugin name="cordova-plugin-local-notification" spec="^0.9.0-beta.2" />
     <plugin name="cordova-plugin-zip" spec="^3.1.0" />
+    <plugin name="cordova-plugin-android-fingerprint-auth" spec="^1.4.3" />
     <engine name="android" spec="6.4.0" />
     <engine name="browser" spec="^5.0.3" />
 </widget>

--- a/package-lock.json
+++ b/package-lock.json
@@ -239,6 +239,11 @@
         "tslib": "1.8.0"
       }
     },
+    "@ionic-native/android-fingerprint-auth": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@ionic-native/android-fingerprint-auth/-/android-fingerprint-auth-4.6.0.tgz",
+      "integrity": "sha512-8LvTPwXw5Zj3qnkVrTBS3RhmBJ0rie9jF6xBJkMJ6NRzIzty459Mgy5dPaA1GnJxVpybe3P+G6Vkt6LLZyPf7A=="
+    },
     "@ionic-native/camera": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/@ionic-native/camera/-/camera-4.5.2.tgz",
@@ -4321,6 +4326,11 @@
           "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M="
         }
       }
+    },
+    "cordova-plugin-android-fingerprint-auth": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-android-fingerprint-auth/-/cordova-plugin-android-fingerprint-auth-1.4.3.tgz",
+      "integrity": "sha512-FYXtPxiemRg9Sb75ZC7yO/BD00bChqph/e19qA0LVl9eNEkVVMv22hingF+CXdGqmdstClKPqupf66Djdi7kGQ=="
     },
     "cordova-plugin-badge": {
       "version": "0.8.7",
@@ -13777,7 +13787,11 @@
         "debug": "3.1.0",
         "extend": "3.0.1",
         "form-data": "2.3.2",
+<<<<<<< HEAD
         "formidable": "1.2.1",
+=======
+        "formidable": "1.2.0",
+>>>>>>> #106 wip add android fingerprint auth
         "methods": "1.1.2",
         "mime": "1.5.0",
         "qs": "6.5.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@angular/http": "5.0.3",
     "@angular/platform-browser": "5.0.3",
     "@angular/platform-browser-dynamic": "5.0.3",
+    "@ionic-native/android-fingerprint-auth": "^4.6.0",
     "@ionic-native/camera": "^4.5.2",
     "@ionic-native/core": "4.4.2",
     "@ionic-native/document-viewer": "^4.5.2",
@@ -53,6 +54,7 @@
     "cordova": "^8.0.0",
     "cordova-android": "6.4.0",
     "cordova-browser": "^5.0.3",
+    "cordova-plugin-android-fingerprint-auth": "^1.4.3",
     "cordova-plugin-badge": "^0.8.7",
     "cordova-plugin-camera": "^3.0.0",
     "cordova-plugin-device": "^1.1.7",
@@ -126,7 +128,8 @@
       "cordova-plugin-file-opener2": {},
       "cordova-plugin-email-composer": {},
       "cordova-plugin-local-notification": {},
-      "cordova-plugin-zip": {}
+      "cordova-plugin-zip": {},
+      "cordova-plugin-android-fingerprint-auth": {}
     },
     "platforms": [
       "android",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -7,7 +7,7 @@ import { IonicApp, IonicModule, IonicErrorHandler } from 'ionic-angular';
 import { MyApp } from './app.component';
 import { AppProviders } from './app.providers';
 
-
+import { AndroidFingerprintAuth } from '@ionic-native/android-fingerprint-auth';
 import { StatusBar } from '@ionic-native/status-bar';
 import { SplashScreen } from '@ionic-native/splash-screen';
 
@@ -22,7 +22,7 @@ import { PortfolioModule } from '@pages/portfolio/portfolio.module';
 import { DiaryModule } from '@pages/diary/diary.module';
 import { RemindersModule } from '@pages/reminders/reminders.module';
 import { SurveyButtonComponent } from '@components/survey-button/survey-button.component';
-import { TourPage } from '@pages/tour//tour';
+import { TourPage } from '@pages/tour/tour';
 import { BrMaskerModule } from 'brmasker-ionic-3';
 
 @NgModule({

--- a/src/app/app.providers.ts
+++ b/src/app/app.providers.ts
@@ -4,15 +4,8 @@ import { FileChooser } from '@ionic-native/file-chooser';
 import { EmailComposer } from '@ionic-native/email-composer';
 import { StatusBar } from '@ionic-native/status-bar';
 import { SplashScreen } from '@ionic-native/splash-screen';
+import { AndroidFingerprintAuth } from '@ionic-native/android-fingerprint-auth';
 import { RemindersService } from '@services/reminders/reminders.service';
-
-class FileChooserMock extends FileChooser {
-  open(): Promise<string> {
-    return new Promise((resolve, reject) => {
-      resolve('');
-    });
-  }
-}
 
 interface EmailComposerOptions {
     app?: string;
@@ -23,6 +16,37 @@ interface EmailComposerOptions {
     subject?: string;
     body?: string;
     isHtml?: boolean;
+}
+interface AFAAuthOptions {
+  clientId: string;
+  username?: string;
+  password?: string;
+  token?: string;
+  disableBackup?: boolean;
+  locale?: string;
+  maxAttempts?: number;
+  userAuthRequired?: boolean;
+  dialogTitle?: string;
+  dialogMessage?: string;
+  dialogHint?: string;
+}
+interface AFADecryptOptions {
+  withFingerprint: boolean;
+  withBackup: boolean;
+  password: string;
+}
+interface AFAEncryptResponse {
+  withFingerprint: boolean;
+  withBackup: boolean;
+  token: string;
+}
+
+class FileChooserMock extends FileChooser {
+  open(): Promise<string> {
+    return new Promise((resolve, reject) => {
+      resolve('');
+    });
+  }
 }
 
 class EmailComposerMock extends EmailComposer {
@@ -76,6 +100,66 @@ class SplashScreenMock extends SplashScreen {
   hide(): void {}
 }
 
+class AndroidFingerprintAuthMock extends AndroidFingerprintAuth {
+  ERRORS: {
+      BAD_PADDING_EXCEPTION: 'BAD_PADDING_EXCEPTION';
+      CERTIFICATE_EXCEPTION: 'CERTIFICATE_EXCEPTION';
+      FINGERPRINT_CANCELLED: 'FINGERPRINT_CANCELLED';
+      FINGERPRINT_DATA_NOT_DELETED: 'FINGERPRINT_DATA_NOT_DELETED';
+      FINGERPRINT_ERROR: 'FINGERPRINT_ERROR';
+      FINGERPRINT_NOT_AVAILABLE: 'FINGERPRINT_NOT_AVAILABLE';
+      FINGERPRINT_PERMISSION_DENIED: 'FINGERPRINT_PERMISSION_DENIED';
+      FINGERPRINT_PERMISSION_DENIED_SHOW_REQUEST: 'FINGERPRINT_PERMISSION_DENIED_SHOW_REQUEST';
+      ILLEGAL_BLOCK_SIZE_EXCEPTION: 'ILLEGAL_BLOCK_SIZE_EXCEPTION';
+      INIT_CIPHER_FAILED: 'INIT_CIPHER_FAILED';
+      INVALID_ALGORITHM_PARAMETER_EXCEPTION: 'INVALID_ALGORITHM_PARAMETER_EXCEPTION';
+      IO_EXCEPTION: 'IO_EXCEPTION';
+      JSON_EXCEPTION: 'JSON_EXCEPTION';
+      MINIMUM_SDK: 'MINIMUM_SDK';
+      MISSING_ACTION_PARAMETERS: 'MISSING_ACTION_PARAMETERS';
+      MISSING_PARAMETERS: 'MISSING_PARAMETERS';
+      NO_SUCH_ALGORITHM_EXCEPTION: 'NO_SUCH_ALGORITHM_EXCEPTION';
+      SECURITY_EXCEPTION: 'SECURITY_EXCEPTION';
+  };
+
+  encrypt(options: AFAAuthOptions): Promise<AFAEncryptResponse> {
+      let reponse: AFAEncryptResponse;
+      return new Promise((resolve, reject) => {
+          resolve(reponse);
+      });
+  }
+
+  decrypt(options: AFAAuthOptions): Promise<AFADecryptOptions> {
+      let reponse: AFADecryptOptions;
+      return new Promise((resolve, reject) => {
+          resolve(reponse);
+      });
+  }
+
+  isAvailable(): Promise<{
+      isAvailable: boolean;
+      isHardwareDetected: boolean;
+      hasEnrolledFingerprints: boolean;
+  }> {
+      const reponse: { isAvailable: boolean, isHardwareDetected: boolean, hasEnrolledFingerprints: boolean} = {isAvailable: true, isHardwareDetected: true, hasEnrolledFingerprints: true};
+      return new Promise((resolve, reject) => {
+          resolve(reponse);
+      });
+  }
+
+  delete(options: {
+      clientId: string;
+      username: string;
+  }): Promise<{
+      deleted: boolean;
+  }> {
+      let reponse: { deleted: boolean};
+      return new Promise((resolve, reject) => {
+          resolve(reponse);
+      });
+  }
+}
+
 export class AppProviders {
   public static getProviders() {
     let providers;
@@ -88,7 +172,8 @@ export class AppProviders {
         { provide: StatusBar, useClass: StatusBarMock },
         { provide: SplashScreen, useClass: SplashScreenMock },
         { provide: ErrorHandler, useClass: IonicErrorHandler },
-        { provide: RemindersService, useClass: RemindersService}
+        { provide: RemindersService, useClass: RemindersService },
+        { provide: AndroidFingerprintAuth, useClass: AndroidFingerprintAuthMock }
       ];
     } else {
       // Use device providers
@@ -97,7 +182,8 @@ export class AppProviders {
         EmailComposer,
         StatusBar,
         SplashScreen,
-        { provide: ErrorHandler, useClass: IonicErrorHandler }
+        { provide: ErrorHandler, useClass: IonicErrorHandler },
+        AndroidFingerprintAuth
       ];
     }
 

--- a/src/pages/password-prompt/password-prompt.ts
+++ b/src/pages/password-prompt/password-prompt.ts
@@ -1,27 +1,32 @@
 import { SHA256 } from 'crypto-js';
 import { ProfileInfoPage } from '@pages/profile-info/profile-info';
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { IonicPage, NavController, NavParams, MenuController, AlertController } from 'ionic-angular';
 import { ProfileService } from '@services/profile/profile.service';
-
+import { AndroidFingerprintAuth } from '@ionic-native/android-fingerprint-auth';
 
 @IonicPage()
 @Component({
   selector: 'page-password-prompt',
-  templateUrl: 'password-prompt.html',
+  templateUrl: 'password-prompt.html'
 })
-export class PasswordPromptPage {
-password: string;
-  constructor(public navCtrl: NavController,
+export class PasswordPromptPage implements OnInit {
+  password: string;
+  constructor(
+    public navCtrl: NavController,
     public navParams: NavParams,
     private profileService: ProfileService,
     public menu: MenuController,
-    public alertCtrl: AlertController) {
-      this.menu.swipeEnable(false, 'left');
+    public alertCtrl: AlertController,
+    private androidFingerprintAuth: AndroidFingerprintAuth
+  ) {
+    this.menu.swipeEnable(false, 'left');
   }
   async checkPwd() {
     await this.profileService.getCurrentProfile().then(profile => {
-      if (profile.password === SHA256(profile.salt + this.password).toString()) {
+      if (
+        profile.password === SHA256(profile.salt + this.password).toString()
+      ) {
         this.menu.swipeEnable(true, 'left');
         this.navCtrl.setRoot(ProfileInfoPage);
       } else {
@@ -34,5 +39,27 @@ password: string;
       }
     });
   }
-
+  async ngOnInit() {
+    this.androidFingerprintAuth
+      .isAvailable()
+      .then(result => {
+        if (result.isAvailable) {
+          this.androidFingerprintAuth.encrypt({ clientId: 'PatientFocus', username: 'myUsername', password: 'myPassword' })
+            .then(result => {
+              if (result.withFingerprint || result.withBackup) {
+                  this.menu.swipeEnable(true, 'left');
+                  this.navCtrl.setRoot(ProfileInfoPage);
+              } else { console.log('Didn\'t authenticate!'); }
+            })
+            .catch(error => {
+              console.error(error);
+            });
+        } else {
+          console.log('Fingerprint authentication not available');
+        }
+      })
+      .catch(error => {
+        console.error(error);
+      });
+  }
 }


### PR DESCRIPTION
## Observation
Some users wish to use their fingerprint to login the app. If a user's device does not support fingerprint scan authentications, then it will not show up.

## Resolution Description
Add Android fingerprint authentication using the hardware fingerprint scanner.

## Resolution Validation
As the user opens PatientFocus, he/she can login to the app in three different ways:
1- PatientFocus Passcode
2- Native Fingerprint
3- Native Lockscreen Pattern

## Screenshot
![29242643_10160073793160433_1924651175_o](https://user-images.githubusercontent.com/6437556/37679694-17c7c2f4-2c58-11e8-9d79-e26e531cfa6f.jpg)

