### PR TITLE
Feedback/#122 change heart icon to medkit

### DIFF
--- a/src/pages/profile-info/personal-information/personal-information.html
+++ b/src/pages/profile-info/personal-information/personal-information.html
@@ -70,7 +70,7 @@
         <ion-row class="chip-list">
             <ng-container *ngFor="let allergy of allergies">
                 <ion-chip>
-                    <ion-icon name="medkit" color="gray"></ion-icon>
+                    <ion-icon name="pricetag" color="gray"></ion-icon>
                     <ion-label>{{ allergy }}</ion-label>
                     <button ion-button clear color="light" (click)="deleteAllergy(allergy)">
                         <ion-icon name="close-circle"></ion-icon>


### PR DESCRIPTION
#122 Nothing complex - According to @AntonyRobert, heart icons gives cardiovascular connotations. We use a more general icon for allergies and conditions.

<img width="557" alt="screen shot 2018-04-02 at 11 12 49 am" src="https://user-images.githubusercontent.com/6437556/38201578-cecba0f2-3666-11e8-9e13-4dc705a05abd.png">

